### PR TITLE
The `/` has been removed from the "Build from Git on Windows with WSL" section in the installation documentation.

### DIFF
--- a/docs/en/installation/index.html
+++ b/docs/en/installation/index.html
@@ -808,7 +808,7 @@ sudo<span class="w"> </span>apt<span class="w"> </span>install<span class="w"> <
 </ul>
 <div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>conda<span class="w"> </span>activate<span class="w"> </span>lf
 ./build0.sh
-cmake<span class="w"> </span>-DCMAKE_BUILD_TYPE<span class="o">=</span>Debug<span class="w"> </span>-DWITH_LLVM<span class="o">=</span>yes<span class="w"> </span>-DCMAKE_INSTALL_PREFIX<span class="o">=</span><span class="sb">`</span><span class="nb">pwd</span><span class="sb">`</span>/inst<span class="w"> </span>.<span class="se">\</span>
+cmake<span class="w"> </span>-DCMAKE_BUILD_TYPE<span class="o">=</span>Debug<span class="w"> </span>-DWITH_LLVM<span class="o">=</span>yes<span class="w"> </span>-DCMAKE_INSTALL_PREFIX<span class="o">=</span><span class="sb">`</span><span class="nb">pwd</span><span class="sb">`</span>/inst<span class="w"> </span>.<span class="se"></span>
 make<span class="w"> </span>-j8
 </pre></div>
 </div>


### PR DESCRIPTION
That extra / is causing an error when we directly copy the commands.